### PR TITLE
Fix hybrid translator config update

### DIFF
--- a/packages/translators/src/translators/hybrid.ts
+++ b/packages/translators/src/translators/hybrid.ts
@@ -120,6 +120,14 @@ class HybridTranslator {
         // Get translators that support new language setting.
         const availableTranslators = this.getAvailableTranslatorsFor(from, to);
 
+        // If no translator supports this language setting, keep current config.
+        if (availableTranslators.length === 0) {
+            console.error(
+                `No translators available for language pair: ${from} -> ${to}`
+            );
+            return this.CONFIG;
+        }
+
         // Replace translators that don't support new language setting with a default translator.
         const defaultTranslator = availableTranslators[0];
 


### PR DESCRIPTION
## Summary
- handle unsupported language pair in HybridTranslator

## Testing
- `yarn workspace @edge_translate/translators test` *(fails: SSL wrong version number)*
- `yarn workspace edge_translate test` *(fails: Cannot read properties of undefined (reading 'testEnvironmentOptions'))*

------
https://chatgpt.com/codex/tasks/task_e_683f7dfd865c83339ebe98cc90045da0