### PR TITLE
Update CI Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: "12"
+                  node-version: "18"
             - name: install dependencies
               run: yarn install
             - name: build packages for chrome and firefox


### PR DESCRIPTION
## Summary
- use Node 18 in CI workflow

## Testing
- `yarn install`
- `yarn build` *(fails: did not detect in-use package manager)*
- `yarn test` *(fails: did not detect in-use package manager)*


------
https://chatgpt.com/codex/tasks/task_e_683f887cbf048333b2c25b9d4b76a29e

Hey there!
Just a quick heads-up: we've linked this PR to its Monday task for you
👉 https://ensideandersoncom-squad.monday.com/boards/9988466343/pulses/9988469824
Going forward, you'll need to handle this yourself by including the item ID in the PR title or description. This ensures it connects properly to the task in Monday.
Thanks!
monday dev team 💚