### PR TITLE
Handle audio play errors

### DIFF
--- a/packages/translators/src/translators/baidu.ts
+++ b/packages/translators/src/translators/baidu.ts
@@ -545,10 +545,25 @@ class BaiduTranslator {
         try {
             await this.AUDIO.play();
         } catch (error: any) {
-            // TODO: error might be NET_ERR or API_ERR, should be handled differently.
+            const errCode = (this.AUDIO as any).error?.code;
+            if (errCode === 2 || errCode === undefined) {
+                throw {
+                    errorType: "NET_ERR",
+                    errorCode: 0,
+                    errorMsg: error.message,
+                    errorAct: {
+                        api: "baidu",
+                        action: "pronounce",
+                        text,
+                        from: language,
+                        to: null,
+                    },
+                };
+            }
+
             throw {
-                errorType: "NET_ERR",
-                errorCode: 0,
+                errorType: "API_ERR",
+                errorCode: errCode,
                 errorMsg: error.message,
                 errorAct: {
                     api: "baidu",

--- a/packages/translators/src/translators/google.ts
+++ b/packages/translators/src/translators/google.ts
@@ -620,10 +620,25 @@ class GoogleTranslator {
         try {
             await this.AUDIO.play();
         } catch (error: any) {
-            // TODO: handle API_ERR and NET_ERR differently.
+            const errCode = (this.AUDIO as any).error?.code;
+            if (errCode === 2 || errCode === undefined) {
+                throw {
+                    errorType: "NET_ERR",
+                    errorCode: 0,
+                    errorMsg: error.message,
+                    errorAct: {
+                        api: "google",
+                        action: "pronounce",
+                        text,
+                        from: language,
+                        to: null,
+                    },
+                };
+            }
+
             throw {
-                errorType: "NET_ERR",
-                errorCode: 0,
+                errorType: "API_ERR",
+                errorCode: errCode,
                 errorMsg: error.message,
                 errorAct: {
                     api: "google",

--- a/packages/translators/src/translators/tencent.ts
+++ b/packages/translators/src/translators/tencent.ts
@@ -421,10 +421,25 @@ class TencentTranslator {
                     return pronounceOnce();
                 }
 
-                // TODO: handle NET_ERR and API_ERR differently.
+                const errCode = (this.AUDIO as any).error?.code;
+                if (errCode === 2 || errCode === undefined) {
+                    throw {
+                        errorType: "NET_ERR",
+                        errorCode: 0,
+                        errorMsg: error.message,
+                        errorAct: {
+                            api: "tencent",
+                            action: "pronounce",
+                            text,
+                            from: language,
+                            to: null,
+                        },
+                    };
+                }
+
                 throw {
-                    errorType: "NET_ERR",
-                    errorCode: 0,
+                    errorType: "API_ERR",
+                    errorCode: errCode,
                     errorMsg: error.message,
                     errorAct: {
                         api: "tencent",

--- a/packages/translators/test/baidu.test.ts
+++ b/packages/translators/test/baidu.test.ts
@@ -40,4 +40,32 @@ describe("baidu translator api", () => {
         expect(parseResult.definitions![0].pos).toBeDefined();
         expect(parseResult.examples!.length).toBeGreaterThan(0);
     });
+
+    it("to handle network error when pronouncing", async () => {
+        const translator = new BaiduTranslator();
+        translator.AUDIO = {
+            paused: true,
+            play: jest.fn(() => Promise.reject(new Error("fail"))),
+            pause: jest.fn(),
+            error: { code: 2 },
+        } as any;
+
+        await expect(
+            translator.pronounce("hello", "en", "fast")
+        ).rejects.toMatchObject({ errorType: "NET_ERR" });
+    });
+
+    it("to handle api error when pronouncing", async () => {
+        const translator = new BaiduTranslator();
+        translator.AUDIO = {
+            paused: true,
+            play: jest.fn(() => Promise.reject(new Error("fail"))),
+            pause: jest.fn(),
+            error: { code: 4 },
+        } as any;
+
+        await expect(
+            translator.pronounce("hello", "en", "fast")
+        ).rejects.toMatchObject({ errorType: "API_ERR", errorCode: 4 });
+    });
 });

--- a/packages/translators/test/google.test.ts
+++ b/packages/translators/test/google.test.ts
@@ -68,4 +68,32 @@ describe("google translator api", () => {
                 done(error);
             });
     });
+
+    it("to handle network error when pronouncing", async () => {
+        const translator = new GoogleTranslator();
+        translator.AUDIO = {
+            paused: true,
+            play: jest.fn(() => Promise.reject(new Error("fail"))),
+            pause: jest.fn(),
+            error: { code: 2 },
+        } as any;
+
+        await expect(
+            translator.pronounce("hello", "en", "fast")
+        ).rejects.toMatchObject({ errorType: "NET_ERR" });
+    });
+
+    it("to handle api error when pronouncing", async () => {
+        const translator = new GoogleTranslator();
+        translator.AUDIO = {
+            paused: true,
+            play: jest.fn(() => Promise.reject(new Error("fail"))),
+            pause: jest.fn(),
+            error: { code: 4 },
+        } as any;
+
+        await expect(
+            translator.pronounce("hello", "en", "fast")
+        ).rejects.toMatchObject({ errorType: "API_ERR", errorCode: 4 });
+    });
 });

--- a/packages/translators/test/tencent.test.ts
+++ b/packages/translators/test/tencent.test.ts
@@ -23,4 +23,42 @@ describe("tencent translator api", () => {
             expect(result).toEqual("zh-CN");
         });
     });
+
+    it("to handle network error when pronouncing", async () => {
+        const t = new TRANSLATOR({});
+        t.AUDIO = {
+            paused: true,
+            play: jest.fn(() => Promise.reject(new Error("fail"))),
+            pause: jest.fn(),
+            error: { code: 2 },
+        } as any;
+
+        // mock cookie
+        chrome.cookies.get = jest
+            .fn()
+            .mockImplementation((_opts, callback) => callback({ value: "x" }));
+
+        await expect(t.pronounce("hello", "en", "fast")).rejects.toMatchObject({
+            errorType: "NET_ERR",
+        });
+    });
+
+    it("to handle api error when pronouncing", async () => {
+        const t = new TRANSLATOR({});
+        t.AUDIO = {
+            paused: true,
+            play: jest.fn(() => Promise.reject(new Error("fail"))),
+            pause: jest.fn(),
+            error: { code: 4 },
+        } as any;
+
+        chrome.cookies.get = jest
+            .fn()
+            .mockImplementation((_opts, callback) => callback({ value: "x" }));
+
+        await expect(t.pronounce("hello", "en", "fast")).rejects.toMatchObject({
+            errorType: "API_ERR",
+            errorCode: 4,
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- catch audio play failures by network vs API error
- test for NET_ERR and API_ERR when playing audio fails

## Testing
- `yarn workspace @edge_translate/translators test` *(fails: Internal Error - package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683f8b27f9288333a0c1919a37d00516