### PR TITLE
Fix wood profitability CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 **/.DS_Store
 **/.idea
 **/*.log
+.yarn
+.yarnrc.yml

--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ After building finished, you will get the unpacked extension under `./packages/E
 
 [Wiki](./docs/wiki/en/Introduction.md)
 
+[Wood Profitability Module](./docs/wiki/en/WoodProfitabilityModule.md)
+[Wood Profitability CLI](./packages/wood-profitability/README.md)
+
 ## Contact Us
 
 E-mails: [nickyc975](mailto:chenjinlong2016@outlook.com), [Mark Fenng](mailto:f18846188605@gmail.com)

--- a/docs/wiki/en/WoodProfitabilityModule.md
+++ b/docs/wiki/en/WoodProfitabilityModule.md
@@ -1,0 +1,26 @@
+# Wood Profitability Module Overview
+
+This document outlines how to build a separate module for managing wood purchases and calculating profitability. The existing repository focuses on the translation extension and does not include these features.
+
+## Suggested Architecture
+
+1. **Backend**
+   - Build a REST API using Node.js (Express or NestJS) or a framework of your choice.
+   - Store transactions, suppliers and clients in a relational database such as PostgreSQL.
+   - Endpoints should allow creating, updating and querying purchase records, freight costs and sales data.
+
+2. **Frontend**
+   - Implement a small web interface (React, Vue or Angular) for data entry and dashboards.
+   - Provide forms to input quantities, dimensions, purchase prices, sale prices and transportation expenses.
+
+3. **Profit Calculations**
+   - Total cost = (purchase price × volume) + freight + any extra charges.
+   - Revenue = volume sold × selling price per cubic meter.
+   - Profit = revenue – total cost.
+   - Margin (%) = (profit / revenue) × 100.
+
+4. **Reports**
+   - Display tables or charts showing profit per supplier, per shipment and over time.
+   - Compare "retirar" and "colocado" pricing to assess freight impact.
+
+This module can live in a new repository separate from Edge Translate to avoid mixing concerns. After deploying the backend and frontend, you can import your spreadsheet data to generate the desired profitability analysis.

--- a/packages/wood-profitability/README.md
+++ b/packages/wood-profitability/README.md
@@ -1,0 +1,22 @@
+# Wood Profitability CLI
+
+This simple script calculates revenue, cost and profit from a CSV file.
+
+## Usage
+
+Prepare a CSV file with column headers like (both dot and comma decimal
+separators are supported; if you use comma decimals, separate columns with a semicolon):
+
+```
+product,volume_m3,buy_price,sell_price,freight_per_m3
+Pinus,28,900,1350,211.54
+Pinus Seco;7;900;1350;211,54
+```
+
+Run the script:
+
+```
+npm --workspace packages/wood-profitability start data.csv
+```
+
+The output prints the total revenue, cost and profit.

--- a/packages/wood-profitability/index.js
+++ b/packages/wood-profitability/index.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+function usage() {
+  console.log('Usage: node index.js <file.csv>');
+  process.exit(1);
+}
+
+if (process.argv.length < 3) {
+  usage();
+}
+
+const filePath = process.argv[2];
+const content = fs.readFileSync(path.resolve(filePath), 'utf-8');
+const firstLine = content.split(/\n/)[0];
+const delimiter = firstLine.includes(';') ? ';' : ',';
+const lines = content.trim().split(/\r?\n/);
+const headers = lines.shift().split(delimiter).map(h => h.trim());
+const records = lines.map(line => {
+  const cells = line.split(delimiter);
+  const record = {};
+  headers.forEach((h, i) => {
+    record[h] = (cells[i] || '').trim();
+  });
+  return record;
+});
+
+function parseNumber(value) {
+  if (typeof value !== 'string') {
+    return parseFloat(value) || 0;
+  }
+  let cleaned = value.replace(/R\$|\$/g, '').trim();
+  if (cleaned.includes(',') && cleaned.includes('.')) {
+    cleaned = cleaned.replace(/\./g, '').replace(',', '.');
+  } else if (cleaned.includes(',')) {
+    cleaned = cleaned.replace(',', '.');
+  }
+  return parseFloat(cleaned) || 0;
+}
+
+let totalRevenue = 0;
+let totalCost = 0;
+
+for (const row of records) {
+  const volume = parseNumber(row.volume_m3 || row.volume || 0);
+  const buy = parseNumber(row.buy_price || row.buy || 0);
+  const sell = parseNumber(row.sell_price || row.sell || 0);
+  const freight = parseNumber(row.freight_per_m3 || row.freight || 0);
+  totalRevenue += sell * volume;
+  totalCost += (buy + freight) * volume;
+}
+
+const profit = totalRevenue - totalCost;
+console.log(`Revenue: ${totalRevenue.toFixed(2)}`);
+console.log(`Cost: ${totalCost.toFixed(2)}`);
+console.log(`Profit: ${profit.toFixed(2)}`);
+

--- a/packages/wood-profitability/package.json
+++ b/packages/wood-profitability/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "wood-profitability",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "description": "Simple CLI to calculate wood profitability from CSV data",
+  "dependencies": {}
+}


### PR DESCRIPTION
## Summary
- add CLI for computing wood profit that does not need external packages
- update `wood-profitability` package to drop csv-parse dependency

## Testing
- `npm test --workspaces` *(fails: jest not found)*
- `node packages/wood-profitability/index.js sample.csv`

------
https://chatgpt.com/codex/tasks/task_e_688577b7db7483338241a11712ebdc70

## Resumo por Sourcery

Adiciona uma CLI autônoma baseada em CSV para calcular a lucratividade da madeira, fornece orientação arquitetônica através de uma nova wiki de módulo e atualiza a documentação para destacar essas adições.

Novas Funcionalidades:
- Adiciona uma CLI de lucratividade da madeira para calcular receita, custo e lucro a partir de entradas CSV sem dependências externas
- Introduz um guia wiki do WoodProfitabilityModule detalhando a arquitetura de backend, frontend e relatórios

Documentação:
- Linka a nova CLI e a documentação do módulo no README raiz
- Adiciona um README dedicado para o pacote de lucratividade da madeira
- Adiciona uma página wiki para o Módulo de Lucratividade da Madeira

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a self-contained CSV-based CLI for calculating wood profitability, provide architectural guidance via a new module wiki, and update documentation to surface these additions.

New Features:
- Add a wood-profitability CLI to compute revenue, cost, and profit from CSV inputs without external dependencies
- Introduce a WoodProfitabilityModule wiki guide outlining backend, frontend, and reporting architecture

Documentation:
- Link the new CLI and module docs in the root README
- Add a dedicated README for the wood-profitability package
- Add a wiki page for the Wood Profitability Module

</details>